### PR TITLE
cgo: fix test case using noescape

### DIFF
--- a/src/cmd/cgo/internal/testerrors/testdata/notmatchedcfunction.go
+++ b/src/cmd/cgo/internal/testerrors/testdata/notmatchedcfunction.go
@@ -5,8 +5,7 @@
 package main
 
 /*
-// TODO(#56378): change back to "#cgo noescape noMatchedCFunction: no matched C function" in Go 1.23
-// ERROR MESSAGE: #cgo noescape disabled until Go 1.23
+// ERROR MESSAGE: #cgo noescape noMatchedCFunction: no matched C function
 #cgo noescape noMatchedCFunction
 */
 import "C"


### PR DESCRIPTION
Update the cgo test case since noescape was enabled commit 9817e278cda9731a712b140201a70e15cd5f3f1e.

In particular, the following test case was failing:

```
--- FAIL: TestNotMatchedCFunction (0.00s)
    --- FAIL: TestNotMatchedCFunction/notmatchedcfunction.go (0.19s)
        errors_test.go:92: expected error output to contain `#cgo noescape disabled until Go 1.23`
        errors_test.go:97: actual output:
            # command-line-arguments
            cgo: #cgo noescape noMatchedCFunction: no matched C function
FAIL
FAIL	cmd/cgo/internal/testerrors	39.806s
```